### PR TITLE
feat: removing babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,9 @@
   "devDependencies": {
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
-    "babel-plugin-transform-object-rest-spread": "6.20.2",
     "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "6.20.2",
     "babel-plugin-transform-react-jsx": "6.24.1",
-    "babel-polyfill": "6.20.0",
     "babel-preset-env": "1.6.0",
     "babel-preset-react": "6.16.0",
     "css-loader": "^0.28.10",
@@ -42,6 +41,7 @@
     "webpack": "3.8.1"
   },
   "dependencies": {
+    "idempotent-babel-polyfill": "^7.0.0",
     "react": "16.4.2",
     "react-dom": "16.4.2",
     "recompose": "0.30.0"

--- a/src/components/Staw/index.js
+++ b/src/components/Staw/index.js
@@ -1,4 +1,4 @@
-import 'babel-polyfill';
+import 'idempotent-babel-polyfill'
 import stawContainer from '../../containers/Staw'
 import Swipper from '../Swipper'
 import StawControls from './Controls'


### PR DESCRIPTION
Opa, o babel-polyfill está sendo adicionado no projeto, e nem sempre é necessário porque o projeto main já pode ter, e isso causa um problema de duas instancias. Pra resolver isso, basta fazer uma condicao pra verificar se já tem ou nao, mas se substituir a lib babel-polyfill pela `idempotent-babel-polyfill` que já faz essa verificacao.